### PR TITLE
Set Next.js output option to standalone

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone"
 };
 
 export default nextConfig;


### PR DESCRIPTION
Update the Next.js configuration to set the output option to "standalone" for improved deployment flexibility.