### PR TITLE
Fix issue #24: [Client] 乗り換え変換ツールのページ構成

### DIFF
--- a/client/app/convert-transfers/page.tsx
+++ b/client/app/convert-transfers/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from 'react';
+import { Tabs, Button, Textarea } from '@mantine/core';
 
 import styles from './page.module.css';
 
@@ -9,28 +10,21 @@ export default function ConvertTransfers() {
   return (
     <div className={styles.page}>
       <h1>乗り換え変換ツール</h1>
-      <div className={styles.tabs}>
-        <button
-          className={`${styles.tabButton} ${activeTab === 'Before' ? styles.activeTab : ''}`}
-          onClick={() => setActiveTab('Before')}
-        >
-          Before
-        </button>
-        <button
-          className={`${styles.tabButton} ${activeTab === 'After' ? styles.activeTab : ''}`}
-          onClick={() => setActiveTab('After')}
-        >
-          After
-        </button>
-      </div>
-      <div className={styles.tabContent}>
-        {activeTab === 'Before' && (
-  <div>
-    <textarea rows={10} cols={50} />
-    <br />
-    <button onClick={() => {}}>Read</button>
-    <button onClick={() => {}}>Convert</button>
-  </div>
+      <Tabs value={activeTab} onTabChange={(value) => setActiveTab(value as 'Before' | 'After')}>
+        <Tabs.List>
+          <Tabs.Tab value="Before">Before</Tabs.Tab>
+          <Tabs.Tab value="After">After</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="Before">
+          <Textarea rows={10} />
+          <Button onClick={() => {}}>Read</Button>
+          <Button onClick={() => {}}>Convert</Button>
+        </Tabs.Panel>
+
+        <Tabs.Panel value="After">
+          <Textarea rows={10} />
+          <Button onClick={() => {}}>Copy</Button>
+        </Tabs.Panel>
 )}
         {activeTab === 'After' && (
   <div>
@@ -39,6 +33,7 @@ export default function ConvertTransfers() {
     <button onClick={() => {}}>Copy</button>
   </div>
 )}
+      </Tabs>
       </div>
     </div>
   );

--- a/client/app/convert-transfers/page.tsx
+++ b/client/app/convert-transfers/page.tsx
@@ -24,8 +24,21 @@ export default function ConvertTransfers() {
         </button>
       </div>
       <div className={styles.tabContent}>
-        {activeTab === 'Before' && <div>{/* Before tab content goes here */}</div>}
-        {activeTab === 'After' && <div>{/* After tab content goes here */}</div>}
+        {activeTab === 'Before' && (
+  <div>
+    <textarea rows={10} cols={50} />
+    <br />
+    <button onClick={() => {}}>Read</button>
+    <button onClick={() => {}}>Convert</button>
+  </div>
+)}
+        {activeTab === 'After' && (
+  <div>
+    <textarea rows={10} cols={50} />
+    <br />
+    <button onClick={() => {}}>Copy</button>
+  </div>
+)}
       </div>
     </div>
   );

--- a/client/app/convert-transfers/page.tsx
+++ b/client/app/convert-transfers/page.tsx
@@ -10,7 +10,7 @@ export default function ConvertTransfers() {
   return (
     <div className={styles.page}>
       <h1>乗り換え変換ツール</h1>
-      <Tabs value={activeTab} onTabChange={(value) => setActiveTab(value as 'Before' | 'After')}>
+      <Tabs value={activeTab} onChange={(value) => setActiveTab(value as 'Before' | 'After')}>
         <Tabs.List>
           <Tabs.Tab value="Before">Before</Tabs.Tab>
           <Tabs.Tab value="After">After</Tabs.Tab>

--- a/client/app/convert-transfers/page.tsx
+++ b/client/app/convert-transfers/page.tsx
@@ -15,6 +15,7 @@ export default function ConvertTransfers() {
           <Tabs.Tab value="Before">Before</Tabs.Tab>
           <Tabs.Tab value="After">After</Tabs.Tab>
         </Tabs.List>
+
         <Tabs.Panel value="Before">
           <Textarea rows={10} />
           <Button onClick={() => {}}>Read</Button>
@@ -25,16 +26,7 @@ export default function ConvertTransfers() {
           <Textarea rows={10} />
           <Button onClick={() => {}}>Copy</Button>
         </Tabs.Panel>
-)}
-        {activeTab === 'After' && (
-  <div>
-    <textarea rows={10} cols={50} />
-    <br />
-    <button onClick={() => {}}>Copy</button>
-  </div>
-)}
       </Tabs>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
This pull request updates the `ConvertTransfers` component in `client/app/convert-transfers/page.tsx` to enhance its functionality by adding interactive elements to the "Before" and "After" tabs.

Enhancements to tab functionality:

* **"Before" tab**: Added a `textarea` for user input, along with "Read" and "Convert" buttons for processing the input.
* **"After" tab**: Added a `textarea` for displaying results, along with a "Copy" button for copying the output.