### PR TITLE
Fix issue #50: [Client] 参考文献つくーるの変換処理追加

### DIFF
--- a/client/app/create-bibliography/page.tsx
+++ b/client/app/create-bibliography/page.tsx
@@ -176,11 +176,35 @@ export default function Page() {
           )}
 
           <div>
-            <button onClick={() => {}}>
+            <button onClick={handleConvert}>
               Convert
             </button>
             <button onClick={clearData}>Clear</button>
           </div>
+
+        </div>
+      )}
+
+  const handleConvert = () => {
+    let result = "";
+    if (mode === "Webページ") {
+      result = [
+        `『${webPageData.pageName}』`,
+        webPageData.siteName,
+        webPageData.url,
+        webPageData.accessDate,
+      ].join(", ");
+    } else if (mode === "書籍" || mode === "論文") {
+      result = [
+        `『${bookPaperData.title}』`,
+        bookPaperData.author.split(",").map((author) => author.trim()).join(", "),
+        bookPaperData.publishDate,
+        bookPaperData.accessDate,
+      ].flat().join(", ");
+    }
+    setConvertedText(result);
+    setTab("after");
+  }
         </div>
       )}
 

--- a/client/app/create-bibliography/page.tsx
+++ b/client/app/create-bibliography/page.tsx
@@ -48,6 +48,27 @@ export default function Page() {
     }
   };
 
+  const handleConvert = () => {
+    let result = "";
+    if (mode === "Webページ") {
+      result = [
+        `『${webPageData.pageName}』`,
+        webPageData.siteName,
+        webPageData.url,
+        webPageData.accessDate,
+      ].join(", ");
+    } else if (mode === "書籍" || mode === "論文") {
+      result = [
+        `『${bookPaperData.title}』`,
+        bookPaperData.author.split(",").map((author) => author.trim()).join(", "),
+        bookPaperData.publishDate,
+        bookPaperData.accessDate,
+      ].flat().join(", ");
+    }
+    setConvertedText(result);
+    setTab("after");
+  }
+
   return (
     <div>
       <h1>参考文献つくーる</h1>
@@ -182,29 +203,6 @@ export default function Page() {
             <button onClick={clearData}>Clear</button>
           </div>
 
-        </div>
-      )}
-
-  const handleConvert = () => {
-    let result = "";
-    if (mode === "Webページ") {
-      result = [
-        `『${webPageData.pageName}』`,
-        webPageData.siteName,
-        webPageData.url,
-        webPageData.accessDate,
-      ].join(", ");
-    } else if (mode === "書籍" || mode === "論文") {
-      result = [
-        `『${bookPaperData.title}』`,
-        bookPaperData.author.split(",").map((author) => author.trim()).join(", "),
-        bookPaperData.publishDate,
-        bookPaperData.accessDate,
-      ].flat().join(", ");
-    }
-    setConvertedText(result);
-    setTab("after");
-  }
         </div>
       )}
 


### PR DESCRIPTION
This pull request introduces a new `handleConvert` function in the `Page` component of `client/app/create-bibliography/page.tsx`. This function handles the conversion of input data into a formatted bibliography based on the selected mode.

### Key changes:

#### Feature addition:
* Added the `handleConvert` function to process and format bibliography data based on the selected mode (`"Webページ"`, `"書籍"`, or `"論文"`). It constructs a formatted string using the relevant data fields and updates the state with the converted text and active tab.

#### UI behavior update:
* Updated the `Convert` button's `onClick` handler to use the new `handleConvert` function, enabling the conversion functionality.