### PR TITLE
Fix issue #52: [Client] 参考文献つくーるの閲覧日修正

### DIFF
--- a/client/app/create-bibliography/page.tsx
+++ b/client/app/create-bibliography/page.tsx
@@ -41,10 +41,11 @@ export default function Page() {
   const [convertedText, setConvertedText] = useState<string>("");
 
   const clearData = () => {
+    const today = new Date().toISOString().slice(0, 10);
     if (mode === "Webページ") {
-      setWebPageData({ url: "", pageName: "", siteName: "", accessDate: "2025-07-03" });
+      setWebPageData({ url: "", pageName: "", siteName: "", accessDate: today });
     } else {
-      setBookPaperData({ title: "", author: "", publishDate: "", accessDate: "2025-07-03" });
+      setBookPaperData({ title: "", author: "", publishDate: "", accessDate: today });
     }
   };
 

--- a/client/app/create-bibliography/page.tsx
+++ b/client/app/create-bibliography/page.tsx
@@ -28,14 +28,14 @@ export default function Page() {
     url: "",
     pageName: "",
     siteName: "",
-    accessDate: "2025-07-03",
+    accessDate: new Date().toISOString().split("T")[0],
   });
 
   const [bookPaperData, setBookPaperData] = useState<BookPaperData>({
     title: "",
     author: "",
     publishDate: "",
-    accessDate: "2025-07-03",
+    accessDate: new Date().toISOString().split("T")[0],
   });
 
   const [convertedText, setConvertedText] = useState<string>("");

--- a/client/app/create-bibliography/page.tsx
+++ b/client/app/create-bibliography/page.tsx
@@ -28,23 +28,23 @@ export default function Page() {
     url: "",
     pageName: "",
     siteName: "",
-    accessDate: "",
+    accessDate: "2025-07-03",
   });
 
   const [bookPaperData, setBookPaperData] = useState<BookPaperData>({
     title: "",
     author: "",
     publishDate: "",
-    accessDate: "",
+    accessDate: "2025-07-03",
   });
 
   const [convertedText, setConvertedText] = useState<string>("");
 
   const clearData = () => {
     if (mode === "Webページ") {
-      setWebPageData({ url: "", pageName: "", siteName: "", accessDate: "" });
+      setWebPageData({ url: "", pageName: "", siteName: "", accessDate: "2025-07-03" });
     } else {
-      setBookPaperData({ title: "", author: "", publishDate: "", accessDate: "" });
+      setBookPaperData({ title: "", author: "", publishDate: "", accessDate: "2025-07-03" });
     }
   };
 


### PR DESCRIPTION
This pull request updates the default value for the `accessDate` field in the `Page` component to "2025-07-03". This change affects the initial state, as well as the reset logic for both `webPageData` and `bookPaperData`.

### Changes to default `accessDate` values:

* Updated the initial state of `webPageData` and `bookPaperData` to set `accessDate` to "2025-07-03" instead of an empty string. (`client/app/create-bibliography/page.tsx`, [client/app/create-bibliography/page.tsxL31-R47](diffhunk://#diff-695ff3634cb1e1164b4977a6b15908888a198d1fd0beb02ef2b1ae038b072c34L31-R47))
* Adjusted the `clearData` function to reset `accessDate` to "2025-07-03" for both `webPageData` and `bookPaperData`. (`client/app/create-bibliography/page.tsx`, [client/app/create-bibliography/page.tsxL31-R47](diffhunk://#diff-695ff3634cb1e1164b4977a6b15908888a198d1fd0beb02ef2b1ae038b072c34L31-R47))